### PR TITLE
Set up docker-compose configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.vscode
 /target
 .env

--- a/dkr/app.dockerfile
+++ b/dkr/app.dockerfile
@@ -1,0 +1,23 @@
+# FIXME: Use mariner once they support the latest Rust.
+# FROM mcr.microsoft.com/cbl-mariner/base/rust:1 as builder
+FROM rust:1-bullseye AS builder
+
+COPY Cargo.lock /build/
+COPY Cargo.toml /build/
+COPY src /build/src
+
+# Build the default page
+WORKDIR /build
+
+RUN cargo build --release
+RUN mkdir -p /app && mv target/release/nederlandskie /app/
+
+# FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0
+FROM debian:bullseye-slim
+
+COPY --from=builder /app /app
+
+WORKDIR /app
+EXPOSE 8000
+
+ENTRYPOINT [ "/app/nederlandskie" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,41 @@
+version: '3.8'
+services:
+  db:
+    image: mcr.microsoft.com/cbl-mariner/base/postgres:14
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - '5432:5432'
+    networks:
+      - backend
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d
+      - db:/var/lib/postgresql/data
+  api:
+    build:
+      context: .
+      dockerfile: dkr/app.dockerfile
+    command: 'launch'
+    image: nederlandskie
+    depends_on:
+      - db
+    ports:
+      - 8000:8000
+    networks:
+      - backend
+    # environment:
+    #   DATABASE_URL: 'postgres://postgres:postgres@db/nederlandskie'
+    volumes:
+      - ./.env:/app/.env
+    links:
+      - db
+
+networks:
+  backend:
+
+
+volumes:
+  db:
+    driver: local


### PR DESCRIPTION
This adds another, much simpler way to configure and start up the app using `docker-compose`. The quick start can be minimized to `docker-compose up`